### PR TITLE
h3_flutter 0.6.3, geojson2h3, h3_common, h3_dart,  h3_ffi, h3_web 0.6.1 - update changelogs

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -243,6 +243,7 @@ jobs:
 
   h3_flutter_test_desktop:
     runs-on: ${{ matrix.os }}
+    if: ${{ false }} # disable macos while https://github.com/github/roadmap/issues/620 is open
     strategy:
       matrix:
         os: [macos-latest]

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -184,6 +184,11 @@ jobs:
         with:
           channel: beta
           architecture: x64
+      
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '11'
 
       - name: Disable macos
         run: flutter config --no-enable-macos-desktop

--- a/geojson2h3/CHANGELOG.md
+++ b/geojson2h3/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.6.1
+* Update `h3_common` (v6.0.1) and `test` (v1.22.2) dependencies.
+
 ## 0.6.0
 * Split `h3_dart` library into 5 libraries - `h3_dart`, `h3_ffi`, `h3_web`, `h3_common`, `geojson2h3`
 * **[BREAKING]** Use `BigInt` instead of `int` for h3 indexes due to `web` specific.  

--- a/geojson2h3/pubspec.yaml
+++ b/geojson2h3/pubspec.yaml
@@ -10,7 +10,7 @@ dependencies:
   h3_common: ^0.6.0
 
 dev_dependencies:
-  test: ^1.21.2
+  test: ^1.22.2
   lints: ^2.0.0
   mockito: ^5.2.0
   build_runner: ^2.1.11

--- a/geojson2h3/pubspec.yaml
+++ b/geojson2h3/pubspec.yaml
@@ -1,13 +1,13 @@
 name: geojson2h3
 description: The geojson2h3 library includes a set of utilities for conversion between GeoJSON polygons and H3 hexagon indexes, using h3. Inspired by JS library geojson2h3.
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/festelo/h3_dart
 
 environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dependencies:
-  h3_common: ^0.6.0
+  h3_common: ^0.6.1
 
 dev_dependencies:
   test: ^1.22.2

--- a/geojson2h3/test/geojson2h3_test.mocks.dart
+++ b/geojson2h3/test/geojson2h3_test.mocks.dart
@@ -86,10 +86,16 @@ class MockH3 extends _i1.Mock implements _i2.H3 {
       (super.noSuchMethod(Invocation.method(#hexRing, [h3Index, ringSize]),
           returnValue: <BigInt>[]) as List<BigInt>);
   @override
-  List<BigInt> polyfill({List<_i2.GeoCoord>? coordinates, int? resolution}) =>
+  List<BigInt> polyfill(
+          {List<_i2.GeoCoord>? coordinates,
+          int? resolution,
+          List<List<_i2.GeoCoord>>? holes}) =>
       (super.noSuchMethod(
-          Invocation.method(#polyfill, [],
-              {#coordinates: coordinates, #resolution: resolution}),
+          Invocation.method(#polyfill, [], {
+            #coordinates: coordinates,
+            #resolution: resolution,
+            #holes: holes
+          }),
           returnValue: <BigInt>[]) as List<BigInt>);
   @override
   List<BigInt> compact(List<BigInt>? hexagons) =>

--- a/h3_common/CHANGELOG.md
+++ b/h3_common/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 0.6.1
+* Update test dependency
+* Add `holes` param to `H3.polyfill` function (thanks [@iulian0512](https://github.com/iulian0512))
+* Fix lint warning
+
 ## 0.6.0
 * Split `h3_dart` library into 5 libraries - `h3_dart`, `h3_ffi`, `h3_web`, `h3_common`, `geojson2h3`
 * Use `BigInt` instead of `int` for h3 indexes due to `web` specific.

--- a/h3_common/lib/h3_common.dart
+++ b/h3_common/lib/h3_common.dart
@@ -1,6 +1,5 @@
 export 'src/h3.dart';
 
-export 'src/models/geo_coord.dart';
 export 'src/models/coord_ij.dart';
 export 'src/models/h3_units.dart';
 export 'src/models/h3_exception.dart';

--- a/h3_common/lib/src/h3.dart
+++ b/h3_common/lib/src/h3.dart
@@ -86,6 +86,7 @@ abstract class H3 {
   List<BigInt> polyfill({
     required List<GeoCoord> coordinates,
     required int resolution,
+    List<List<GeoCoord>> holes,
   });
 
   /// Compact a set of hexagons of the same resolution into a set of hexagons

--- a/h3_common/pubspec.yaml
+++ b/h3_common/pubspec.yaml
@@ -1,6 +1,6 @@
 name: h3_common
 description: The package provides Dart version of the H3 Core library, a hexagon-based geographic grid system
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/festelo/h3_dart
 
 environment:

--- a/h3_common/pubspec.yaml
+++ b/h3_common/pubspec.yaml
@@ -7,6 +7,5 @@ environment:
   sdk: ">=2.14.0 <3.0.0"
 
 dev_dependencies:
-
   test: ^1.22.2
   lints: ^2.0.0

--- a/h3_common/pubspec.yaml
+++ b/h3_common/pubspec.yaml
@@ -8,5 +8,5 @@ environment:
 
 dev_dependencies:
 
-  test: ^1.21.2
+  test: ^1.22.2
   lints: ^2.0.0

--- a/h3_dart/CHANGELOG.md
+++ b/h3_dart/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.1
+* Fix `h3_web` setup readme.
+* Add holes support to `polyfill` function (thanks [@iulian0512](https://github.com/iulian0512))
+* Fix Android build for `h3_flutter` (thanks [@rtviwe](https://github.com/iulian0512))
+* Fix `build_h3.sh` script for M1 mac
+* Tests fix
+
 ## 0.6.0
 * Split `h3_dart` library into 5 libraries - `h3_dart`, `h3_ffi`, `h3_web`, `h3_common`, `geojson2h3`
 * Use `BigInt` instead of `int` for h3 indexes due to `web` specific.

--- a/h3_dart/CHANGELOG.md
+++ b/h3_dart/CHANGELOG.md
@@ -1,9 +1,12 @@
 ## 0.6.1
-* Fix `h3_web` setup readme.
-* Add holes support to `polyfill` function (thanks [@iulian0512](https://github.com/iulian0512))
-* Fix Android build for `h3_flutter` (thanks [@rtviwe](https://github.com/iulian0512))
-* Fix `build_h3.sh` script for M1 mac
-* Tests fix
+* Add `holes` param to `H3.polyfill` function (thanks [@iulian0512](https://github.com/iulian0512))
+* Update dependencies
+* Fix web tests
+* Use `h3_web` 0.6.1
+* Use `h3_ffi` 0.6.1
+* Fix web setup readme.
+* Fix web example
+* Fix web test
 
 ## 0.6.0
 * Split `h3_dart` library into 5 libraries - `h3_dart`, `h3_ffi`, `h3_web`, `h3_common`, `geojson2h3`

--- a/h3_dart/README.md
+++ b/h3_dart/README.md
@@ -52,7 +52,7 @@ Place your library somewhere and load it using `final h3 = const H3Factory().byP
 Web version is built on top of `h3-js`, you have to import it.  
 Add next line to your `index.html`:
 ```html
-    <script defer src="https://unpkg.com/h3-js"></script>
+    <script defer src="https://unpkg.com/h3-js@3.7.2"></script>
 ```  
 *Note, `main.dart.js` import should go after this line*  
 

--- a/h3_dart/example/ffi/pubspec.lock
+++ b/h3_dart/example/ffi/pubspec.lock
@@ -9,18 +9,18 @@ packages:
     source: hosted
     version: "2.0.1"
   geojson2h3:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../geojson2h3"
-      relative: true
-    source: path
+      name: geojson2h3
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_dart:
     dependency: "direct main"
@@ -30,18 +30,18 @@ packages:
     source: path
     version: "0.6.0"
   h3_ffi:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_ffi"
-      relative: true
-    source: path
+      name: h3_ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_web:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_web"
-      relative: true
-    source: path
+      name: h3_web
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   js:
     dependency: transitive
@@ -56,7 +56,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.1"
   path:
     dependency: transitive
     description:

--- a/h3_dart/example/ffi/pubspec.lock
+++ b/h3_dart/example/ffi/pubspec.lock
@@ -9,18 +9,18 @@ packages:
     source: hosted
     version: "2.0.1"
   geojson2h3:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: geojson2h3
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../../geojson2h3"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_common:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_common
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../../h3_common"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_dart:
     dependency: "direct main"
@@ -30,18 +30,18 @@ packages:
     source: path
     version: "0.6.0"
   h3_ffi:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_ffi
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../../h3_ffi"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_web:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_web
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../../h3_web"
+      relative: true
+    source: path
     version: "0.6.0"
   js:
     dependency: transitive

--- a/h3_dart/example/ffi/pubspec.lock
+++ b/h3_dart/example/ffi/pubspec.lock
@@ -5,22 +5,25 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   geojson2h3:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../geojson2h3"
-      relative: true
-    source: path
+      name: geojson2h3
+      sha256: "7e6352fcfc8a8e9bf2f6ee628845136f5cec91c64f5c666e63c291a79d29cfcc"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      sha256: "06e8e8543e0c1cdd4dbedcd12f751166704b0bf5d239c27ba2a2e7527a745f2a"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_dart:
     dependency: "direct main"
@@ -30,39 +33,52 @@ packages:
     source: path
     version: "0.6.0"
   h3_ffi:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_ffi"
-      relative: true
-    source: path
+      name: h3_ffi
+      sha256: "92ae60a423a3ea6b248df00e70ba892b458dc094286aff2842ec68eeeaece053"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_web:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_web"
-      relative: true
-    source: path
+      name: h3_web
+      sha256: f97291d19a5196641bca32bb4cb7d6378b1da076792a1969c094fb6389a24231
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "323b7c70073cccf6b9b8d8b334be418a3293cfb612a560dc2737160a37bf61bd"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.6"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
+  meta:
+    dependency: transitive
+    description:
+      name: meta
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.19.0-345.0.dev <4.0.0"

--- a/h3_dart/example/ffi/pubspec.yaml
+++ b/h3_dart/example/ffi/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
     path: ../..
 
 dev_dependencies:
-  lints: ^1.0.0
+  lints: ^2.0.1

--- a/h3_dart/example/web/pubspec.lock
+++ b/h3_dart/example/web/pubspec.lock
@@ -219,11 +219,11 @@ packages:
     source: hosted
     version: "3.2.0"
   geojson2h3:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: geojson2h3
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../../geojson2h3"
+      relative: true
+    source: path
     version: "0.6.0"
   glob:
     dependency: transitive
@@ -240,11 +240,11 @@ packages:
     source: hosted
     version: "2.2.0"
   h3_common:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_common
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../../h3_common"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_dart:
     dependency: "direct main"
@@ -254,18 +254,18 @@ packages:
     source: path
     version: "0.6.0"
   h3_ffi:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_ffi
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../../h3_ffi"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_web:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_web
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../../h3_web"
+      relative: true
+    source: path
     version: "0.6.0"
   http:
     dependency: transitive

--- a/h3_dart/example/web/pubspec.lock
+++ b/h3_dart/example/web/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "40.0.0"
+    version: "52.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "5.4.0"
   archive:
     dependency: transitive
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.5"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   browser_launcher:
     dependency: transitive
     description:
@@ -56,14 +56,14 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
@@ -77,35 +77,35 @@ packages:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.5"
+    version: "4.0.7"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.11"
+    version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.7"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.7"
   built_collection:
     dependency: transitive
     description:
@@ -119,35 +119,35 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.3.3"
+    version: "8.4.3"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   crypto:
     dependency: transitive
     description:
@@ -161,35 +161,35 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   dds:
     dependency: transitive
     description:
       name: dds
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.7.2"
   dds_service_extensions:
     dependency: transitive
     description:
       name: dds_service_extensions
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   devtools_shared:
     dependency: transitive
     description:
       name: devtools_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.14.0"
+    version: "2.20.1"
   dwds:
     dependency: transitive
     description:
       name: dwds
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "14.0.3"
+    version: "16.0.1"
   ffi:
     dependency: transitive
     description:
@@ -203,7 +203,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
@@ -217,13 +217,13 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.2.0"
   geojson2h3:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../geojson2h3"
-      relative: true
-    source: path
+      name: geojson2h3
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   glob:
     dependency: transitive
@@ -231,20 +231,20 @@ packages:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_dart:
     dependency: "direct main"
@@ -254,18 +254,18 @@ packages:
     source: path
     version: "0.6.0"
   h3_ffi:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_ffi"
-      relative: true
-    source: path
+      name: h3_ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_web:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_web"
-      relative: true
-    source: path
+      name: h3_web
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   http:
     dependency: transitive
@@ -273,7 +273,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
@@ -287,28 +287,28 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.0"
+    version: "4.8.0"
   json_rpc_2:
     dependency: transitive
     description:
@@ -322,21 +322,21 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.14"
   meta:
     dependency: transitive
     description:
@@ -350,7 +350,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   package_config:
     dependency: transitive
     description:
@@ -364,14 +364,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
-  pedantic:
+    version: "1.8.3"
+  pointycastle:
     dependency: transitive
     description:
-      name: pedantic
+      name: pointycastle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.1"
+    version: "3.6.2"
   pool:
     dependency: transitive
     description:
@@ -392,14 +392,14 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   scratch_space:
     dependency: transitive
     description:
@@ -413,7 +413,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -441,56 +441,56 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.11"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sse:
     dependency: transitive
     description:
       name: sse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.1.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -504,7 +504,7 @@ packages:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
@@ -525,42 +525,42 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   webdev:
     dependency: "direct dev"
     description:
       name: webdev
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.9"
+    version: "2.7.12"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -569,4 +569,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/h3_dart/example/web/pubspec.lock
+++ b/h3_dart/example/web/pubspec.lock
@@ -5,246 +5,281 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
+      url: "https://pub.dev"
     source: hosted
     version: "52.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
+      url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: ed7cc591a948744994714375caf9a2ce89e1d82e8243997c8a2994d57181c212
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.5"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
     version: "2.10.0"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
-      url: "https://pub.dartlang.org"
+      sha256: "500584fdb80bcb70a2990a5838338a757cc24bbf27d88bf791cbe9461c57cd5a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   browser_launcher:
     dependency: transitive
     description:
       name: browser_launcher
-      url: "https://pub.dartlang.org"
+      sha256: "6ee4c6b1f68a42e769ef6e663c4f56708522f7bce9d2ab6e308a37b612ffa4ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
-      url: "https://pub.dartlang.org"
+      sha256: d02a5b40720692c8c4c385741afb1cc50b53f192a33fa5da1f2bdaec3ec6db3e
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.7"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: "7c35a3a7868626257d8aee47b51c26b9dba11eaddf3431117ed2744951416aab"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.7"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
-      url: "https://pub.dartlang.org"
+      sha256: ee45348ba9c2dfd2e165c0adf69311970fa620c6669c345ab533e16d0d119e3d
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.7"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "169565c8ad06adb760c3645bf71f00bff161b00002cace266cad42c5d22a7725"
+      url: "https://pub.dev"
     source: hosted
     version: "8.4.3"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
+      url: "https://pub.dev"
     source: hosted
     version: "4.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
     version: "1.17.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
   dds:
     dependency: transitive
     description:
       name: dds
-      url: "https://pub.dartlang.org"
+      sha256: a87ad70ffc15deb727f2943618aa999051ea4353dcc2175787931b57039a8c29
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.2"
   dds_service_extensions:
     dependency: transitive
     description:
       name: dds_service_extensions
-      url: "https://pub.dartlang.org"
+      sha256: "5aa29ecb1945743eed6b513ef4871468d14b6c1b6f8a5ec84c03f469e3f94fb2"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   devtools_shared:
     dependency: transitive
     description:
       name: devtools_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0f4264037e7a0f1aeadd425635024ad445b523963b246c61af7ffd22c3ed10da"
+      url: "https://pub.dev"
     source: hosted
     version: "2.20.1"
   dwds:
     dependency: transitive
     description:
       name: dwds
-      url: "https://pub.dartlang.org"
+      sha256: d2fd021d505610e57e07f068647d92f9639dde8a508b68f446a8ada2ea69e071
+      url: "https://pub.dev"
     source: hosted
     version: "16.0.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   geojson2h3:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../geojson2h3"
-      relative: true
-    source: path
+      name: geojson2h3
+      sha256: "7e6352fcfc8a8e9bf2f6ee628845136f5cec91c64f5c666e63c291a79d29cfcc"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      sha256: "06e8e8543e0c1cdd4dbedcd12f751166704b0bf5d239c27ba2a2e7527a745f2a"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_dart:
     dependency: "direct main"
@@ -254,319 +289,364 @@ packages:
     source: path
     version: "0.6.0"
   h3_ffi:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_ffi"
-      relative: true
-    source: path
+      name: h3_ffi
+      sha256: "92ae60a423a3ea6b248df00e70ba892b458dc094286aff2842ec68eeeaece053"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_web:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../../h3_web"
-      relative: true
-    source: path
+      name: h3_web
+      sha256: f97291d19a5196641bca32bb4cb7d6378b1da076792a1969c094fb6389a24231
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   http:
     dependency: transitive
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "323b7c70073cccf6b9b8d8b334be418a3293cfb612a560dc2737160a37bf61bd"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.6"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
   json_rpc_2:
     dependency: transitive
     description:
       name: json_rpc_2
-      url: "https://pub.dartlang.org"
+      sha256: "5e469bffa23899edacb7b22787780068d650b106a21c76db3c49218ab7ca447e"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.14"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      url: "https://pub.dev"
     source: hosted
     version: "3.6.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   protobuf:
     dependency: transitive
     description:
       name: protobuf
-      url: "https://pub.dartlang.org"
+      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   scratch_space:
     dependency: transitive
     description:
       name: scratch_space
-      url: "https://pub.dartlang.org"
+      sha256: a469a9642a4d7ee406d6224a85446eb8baa9dd6d81e2f0b76770deae7bd32aab
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   shelf_proxy:
     dependency: transitive
     description:
       name: shelf_proxy
-      url: "https://pub.dartlang.org"
+      sha256: "3cdbff721092c755927d8695f696e13cff4b3ceb43306de136e69c38d5f574b8"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "490098075234dcedb83c5d949b4c93dad5e6b7702748de000be2b57b8e6b2427"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.11"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   sse:
     dependency: transitive
     description:
       name: sse
-      url: "https://pub.dartlang.org"
+      sha256: "3ff9088cac3f45aa8b91336f1962e3ea6c81baaba0bbba361c05f8aa7fb59442"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   usage:
     dependency: transitive
     description:
       name: usage
-      url: "https://pub.dartlang.org"
+      sha256: ccc861ca619157046d961a1d7fa21a364476c574bb8f3e90219e41b9103adee0
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      url: "https://pub.dartlang.org"
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      url: "https://pub.dev"
     source: hosted
     version: "9.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   webdev:
     dependency: "direct dev"
     description:
       name: webdev
-      url: "https://pub.dartlang.org"
+      sha256: c16fcac5198f4f4dd6189aa75b554a94094ed86b9b3fd041b719ec9650a75b1e
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.12"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.19.0-345.0.dev <4.0.0"

--- a/h3_dart/example/web/pubspec.yaml
+++ b/h3_dart/example/web/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     path: ../..
 
 dev_dependencies:
-  build_runner: ^2.1.4
-  build_web_compilers: ^3.2.1
-  lints: ^1.0.0
-  webdev: ^2.7.9
+  build_runner: ^2.3.3
+  build_web_compilers: ^3.2.7
+  lints: ^2.0.1
+  webdev: ^2.7.12

--- a/h3_dart/example/web/web/index.html
+++ b/h3_dart/example/web/web/index.html
@@ -8,7 +8,7 @@
     <meta name="scaffolded-by" content="https://github.com/dart-lang/sdk">
     <title>example</title>
     <link rel="stylesheet" href="styles.css">
-    <script defer src="https://unpkg.com/h3-js"></script>
+    <script defer src="https://unpkg.com/h3-js@3.7.2"></script>
     <script defer src="main.dart.js"></script>
 </head>
 

--- a/h3_dart/pubspec.yaml
+++ b/h3_dart/pubspec.yaml
@@ -1,6 +1,6 @@
 name: h3_dart
 description: The package provides Dart version of the H3 Core library, a hexagon-based geographic grid system
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/festelo/h3_dart
 
 environment:
@@ -8,10 +8,10 @@ environment:
 
 dependencies:
   ffi: ^2.0.1
-  h3_ffi: ^0.6.0
-  h3_web: ^0.6.0
-  h3_common: ^0.6.0
-  geojson2h3: ^0.6.0
+  h3_ffi: ^0.6.1
+  h3_web: ^0.6.1
+  h3_common: ^0.6.1
+  geojson2h3: ^0.6.1
 
 dev_dependencies: 
   lints: ^2.0.0

--- a/h3_dart/test/h3_dart_web_test.dart
+++ b/h3_dart/test/h3_dart_web_test.dart
@@ -8,7 +8,7 @@ import 'package:h3_dart/h3_dart.dart';
 import 'h3_js_injector.dart';
 
 void main() async {
-  await inject('https://unpkg.com/h3-js');
+  await inject('https://unpkg.com/h3-js@3.7.2');
 
   final h3Factory = const H3Factory();
 

--- a/h3_ffi/CHANGELOG.md
+++ b/h3_ffi/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.6.1
+* Add holes support to `polyfill` function (thanks [@iulian0512](https://github.com/iulian0512))
+* Fix Android build for `h3_flutter` (thanks [@rtviwe](https://github.com/iulian0512))
+* Fix `CMakeLists.txt` and update build instruction for M1 mac
+* Update dependencies
+
 ## 0.6.0
 * Split `h3_dart` library into 5 libraries - `h3_dart`, `h3_ffi`, `h3_web`, `h3_common`, `geojson2h3`
 * Use `BigInt` instead of `int` for h3 indexes due to `web` specific.

--- a/h3_ffi/README.md
+++ b/h3_ffi/README.md
@@ -103,7 +103,6 @@ To run it, you need to install LLVM:
 ```
 brew install llvm
 ```
-If you're using M1 Mac, as of now, you need to install x86 version of LLVM, to do it you need to install x86 version of Homebrew.
 
 All H3 public functions should be specified in ffigen.yaml file
 Run `flutter pub run ffigen --config ffigen.yaml` to generate bindings

--- a/h3_ffi/c/h3lib/CMakeLists.txt
+++ b/h3_ffi/c/h3lib/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.4.1)
-set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "" FORCE)
 project(h3lib)
 
 FILE(GLOB CSources *.c)

--- a/h3_ffi/example/pubspec.lock
+++ b/h3_ffi/example/pubspec.lock
@@ -9,11 +9,11 @@ packages:
     source: hosted
     version: "2.0.1"
   h3_common:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_common
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../h3_common"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_ffi:
     dependency: "direct main"

--- a/h3_ffi/example/pubspec.lock
+++ b/h3_ffi/example/pubspec.lock
@@ -5,15 +5,17 @@ packages:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      sha256: "06e8e8543e0c1cdd4dbedcd12f751166704b0bf5d239c27ba2a2e7527a745f2a"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_ffi:
     dependency: "direct main"
@@ -26,15 +28,17 @@ packages:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.17.0 <4.0.0"

--- a/h3_ffi/example/pubspec.lock
+++ b/h3_ffi/example/pubspec.lock
@@ -9,11 +9,11 @@ packages:
     source: hosted
     version: "2.0.1"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_ffi:
     dependency: "direct main"
@@ -28,7 +28,7 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.1"
   path:
     dependency: transitive
     description:

--- a/h3_ffi/example/pubspec.yaml
+++ b/h3_ffi/example/pubspec.yaml
@@ -11,4 +11,4 @@ dependencies:
     path: ..
 
 dev_dependencies:
-  lints: ^1.0.0
+  lints: ^2.0.1

--- a/h3_ffi/lib/src/h3_ffi.dart
+++ b/h3_ffi/lib/src/h3_ffi.dart
@@ -202,10 +202,12 @@ class H3Ffi implements H3 {
   List<BigInt> polyfill({
     required List<GeoCoord> coordinates,
     required int resolution,
+    List<List<GeoCoord>> holes = const [],
   }) {
     assert(resolution >= 0 && resolution < 16,
         'Resolution must be in [0, 15] range');
     return using((arena) {
+      // polygon outer boundary
       final nativeCoordinatesPointer = arena<c.GeoCoord>(coordinates.length);
       for (var i = 0; i < coordinates.length; i++) {
         final pointer = Pointer<c.GeoCoord>.fromAddress(
@@ -217,12 +219,46 @@ class H3Ffi implements H3 {
       }
 
       final polygon = arena<c.GeoPolygon>();
-      final geofence = arena<c.Geofence>();
-      polygon.ref.geofence = geofence.ref;
+      final outergeofence = arena<c.Geofence>();
+
+      // outer boundary
+      polygon.ref.geofence = outergeofence.ref;
       polygon.ref.geofence.verts = nativeCoordinatesPointer;
       polygon.ref.geofence.numVerts = coordinates.length;
-      polygon.ref.numHoles = 0;
-      polygon.ref.holes = Pointer.fromAddress(0);
+
+      // polygon holes
+      if (holes.isNotEmpty) {
+        final holesgeofencePointer = arena<c.Geofence>(holes.length);
+        for (var h = 0; h < holes.length; h++) {
+          final holeCoords = holes[h];
+
+          final singleHoleGFencePointer = Pointer<c.Geofence>.fromAddress(
+            holesgeofencePointer.address + sizeOf<c.Geofence>() * h,
+          );
+
+          final holeNativeCoordinatesPointer =
+              arena<c.GeoCoord>(holeCoords.length);
+
+          // assign the hole coord to holeptr
+          for (var i = 0; i < holeCoords.length; i++) {
+            final coordPointer = Pointer<c.GeoCoord>.fromAddress(
+                holeNativeCoordinatesPointer.address +
+                    sizeOf<c.GeoCoord>() * i);
+            holeCoords[i]
+                .toRadians(_geoCoordConverter)
+                .assignToNative(coordPointer.ref);
+          }
+
+          singleHoleGFencePointer.ref.numVerts = holeCoords.length;
+          singleHoleGFencePointer.ref.verts = holeNativeCoordinatesPointer;
+        }
+
+        polygon.ref.numHoles = holes.length;
+        polygon.ref.holes = holesgeofencePointer;
+      } else {
+        polygon.ref.numHoles = 0;
+        polygon.ref.holes = Pointer.fromAddress(0);
+      }
 
       final nbIndex = _h3c.maxPolyfillSize(polygon, resolution);
 

--- a/h3_ffi/pubspec.yaml
+++ b/h3_ffi/pubspec.yaml
@@ -1,6 +1,6 @@
 name: h3_ffi
 description: The package provides Dart version of the H3 Core library, a hexagon-based geographic grid system
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/festelo/h3_dart
 
 environment:
@@ -9,7 +9,7 @@ environment:
 dependencies:
   ffi: ^2.0.1
   path: ^1.8.1
-  h3_common: ^0.6.0
+  h3_common: ^0.6.1
 
 dev_dependencies:
   test: ^1.22.2

--- a/h3_ffi/pubspec.yaml
+++ b/h3_ffi/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
   h3_common: ^0.6.0
 
 dev_dependencies:
-  test: ^1.21.2
+  test: ^1.22.2
   lints: ^2.0.0
   ffigen: ^6.0.1
-  collection: ^1.15.0
+  collection: ^1.17.1

--- a/h3_ffi/test/h3_ffi_factory_test.dart
+++ b/h3_ffi/test/h3_ffi_factory_test.dart
@@ -1,5 +1,4 @@
 import 'dart:ffi';
-import 'package:h3_ffi/src/h3_ffi.dart';
 import 'package:test/test.dart';
 import 'package:h3_ffi/h3_ffi.dart';
 import 'package:path/path.dart' as p;

--- a/h3_ffi/test/h3_test.dart
+++ b/h3_ffi/test/h3_test.dart
@@ -344,6 +344,46 @@ void main() {
       );
     });
 
+    test('Hexagon with holes', () async {
+      final resolution = 5;
+      // wkt: POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))
+      final hexagons = h3.polyfill(
+        coordinates: const [
+          GeoCoord(lon: 35, lat: 10),
+          GeoCoord(lon: 45, lat: 45),
+          GeoCoord(lon: 15, lat: 40),
+          GeoCoord(lon: 10, lat: 20),
+          GeoCoord(lon: 35, lat: 10)
+        ],
+        holes: const [
+          [
+            GeoCoord(lon: 20, lat: 30),
+            GeoCoord(lon: 35, lat: 35),
+            GeoCoord(lon: 30, lat: 20),
+            GeoCoord(lon: 20, lat: 30)
+          ]
+        ],
+        resolution: resolution,
+      );
+
+      // point inside the hole 28.037109375000004 28.84467368077179 (this should be classified as outside)
+      //point inside 18.45703125 21.616579336740614
+      //point outside (far away) 52.55859375 23.48340065432562
+
+      final insideHoleIndex = h3.geoToH3(
+          GeoCoord(lon: 28.037109375000004, lat: 28.84467368077179),
+          resolution);
+      expect(hexagons.contains(insideHoleIndex), false);
+
+      final insideIndex = h3.geoToH3(
+          GeoCoord(lon: 18.45703125, lat: 21.616579336740614), resolution);
+      expect(hexagons.contains(insideIndex), true);
+
+      final outsideIndex = h3.geoToH3(
+          GeoCoord(lon: 52.55859375, lat: 23.48340065432562), resolution);
+      expect(hexagons.contains(outsideIndex), false);
+    });
+
     test('Transmeridian', () async {
       final hexagons = h3.polyfill(
         coordinates: const [

--- a/h3_flutter/CHANGELOG.md
+++ b/h3_flutter/CHANGELOG.md
@@ -1,3 +1,13 @@
+## 0.6.3
+* Add `holes` param to `H3.polyfill` function (thanks [@iulian0512](https://github.com/iulian0512))
+* Fix web setup readme.
+* Fix web example
+* Fix web test
+* Fix android build (thanks [@rtviwe](https://github.com/iulian0512))
+* Update dependencies (incl. `h3_web`, `h3_ffi`, `h3_common`, `geojson2h3` v6.0.1 and others)
+* Fix android test setup (github actions)
+* Temporary disable macos test (github actions)
+
 ## 0.6.2
 * Fix Android build
 * Add Android tests

--- a/h3_flutter/README.md
+++ b/h3_flutter/README.md
@@ -39,9 +39,9 @@ final geojson2h3 = Geojson2H3(h3);
 
 ### Web
 
-Web version is built on top of `h3-js`, you have to import it.  
+Web version is built on top of `h3-js` v3.7.2, you have to import it.  
 Add next line to your `index.html`:
 ```html
-    <script defer src="https://unpkg.com/h3-js"></script>
+    <script defer src="https://unpkg.com/h3-js@3.7.2"></script>
 ```  
 *Note, `main.dart.js` import should go after this line*  

--- a/h3_flutter/android/build.gradle
+++ b/h3_flutter/android/build.gradle
@@ -2,14 +2,15 @@ group 'com.example.h3_flutter'
 version '1.0-SNAPSHOT'
 
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.gradle_version = '7.3.1'
+    ext.kotlin_version = '1.7.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath "com.android.tools.build:gradle:$gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/h3_flutter/android/src/h3lib/CMakeLists.txt
+++ b/h3_flutter/android/src/h3lib/CMakeLists.txt
@@ -1,5 +1,4 @@
 cmake_minimum_required(VERSION 3.4.1)
-set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "" FORCE)
 project(h3lib)
 
 FILE(GLOB CSources *.c)

--- a/h3_flutter/example/android/build.gradle
+++ b/h3_flutter/example/android/build.gradle
@@ -7,7 +7,7 @@ buildscript {
     }
 
     dependencies {
-        classpath "com.android.tools.build:$gradle_version"
+        classpath "com.android.tools.build:gradle:$gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/h3_flutter/example/android/build.gradle
+++ b/h3_flutter/example/android/build.gradle
@@ -1,12 +1,13 @@
 buildscript {
-    ext.kotlin_version = '1.4.32'
+    ext.gradle_version = '7.3.1'
+    ext.kotlin_version = '1.7.21'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:4.1.0'
+        classpath "com.android.tools.build:$gradle_version"
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/h3_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/h3_flutter/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.4-all.zip

--- a/h3_flutter/example/macos/Podfile
+++ b/h3_flutter/example/macos/Podfile
@@ -1,4 +1,4 @@
-platform :osx, '10.11'
+platform :osx, '10.14'
 
 # CocoaPods analytics sends network stats synchronously affecting flutter build latency.
 ENV['COCOAPODS_DISABLE_STATS'] = 'true'

--- a/h3_flutter/example/macos/Podfile.lock
+++ b/h3_flutter/example/macos/Podfile.lock
@@ -14,9 +14,9 @@ EXTERNAL SOURCES:
     :path: Flutter/ephemeral/.symlinks/plugins/h3_flutter/macos
 
 SPEC CHECKSUMS:
-  FlutterMacOS: ae6af50a8ea7d6103d888583d46bd8328a7e9811
+  FlutterMacOS: 8f6f14fa908a6fb3fba0cd85dbd81ec4b251fb24
   h3_flutter: e34ec28cdbde31845cff0b2342c72cf380e7e979
 
-PODFILE CHECKSUM: 6eac6b3292e5142cfc23bdeb71848a40ec51c14c
+PODFILE CHECKSUM: 353c8bcc5d5b0994e508d035b5431cfe18c1dea7
 
 COCOAPODS: 1.11.3

--- a/h3_flutter/example/macos/Runner.xcodeproj/project.pbxproj
+++ b/h3_flutter/example/macos/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 51;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXAggregateTarget section */
@@ -256,6 +256,7 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3399D490228B24CF009A79C7 /* ShellScript */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -404,7 +405,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;
@@ -483,7 +484,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = macosx;
@@ -530,7 +531,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				MACOSX_DEPLOYMENT_TARGET = 10.11;
+				MACOSX_DEPLOYMENT_TARGET = 10.14;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = macosx;
 				SWIFT_COMPILATION_MODE = wholemodule;

--- a/h3_flutter/example/pubspec.lock
+++ b/h3_flutter/example/pubspec.lock
@@ -5,77 +5,88 @@ packages:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: "80e5141fafcb3361653ce308776cfd7d45e6e9fbb429e14eec571382c0c5fecb"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
       name: characters
-      url: "https://pub.dartlang.org"
+      sha256: e6a326c8af69605aec75ed6c187d06b349707a27fbff8222ca9cc2cff167975c
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   clock:
     dependency: transitive
     description:
       name: clock
-      url: "https://pub.dartlang.org"
+      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: cfc915e6923fe5ce6e153b0723c753045de46de1b4d63771530504004a45fae0
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.0"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   cupertino_icons:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      url: "https://pub.dartlang.org"
+      sha256: e35129dc44c9118cee2a5603506d823bab99c68393879edb440e0090d07586be
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.4"
+    version: "1.0.5"
   fake_async:
     dependency: transitive
     description:
       name: fake_async
-      url: "https://pub.dartlang.org"
+      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   ffi:
     dependency: transitive
     description:
       name: ffi
-      url: "https://pub.dartlang.org"
+      sha256: a38574032c5f1dd06c4aee541789906c12ccaab8ba01446e800d9c5b79c4a978
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   flutter:
@@ -92,7 +103,8 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      url: "https://pub.dartlang.org"
+      sha256: aeb0b80a8b3709709c9cc496cdc027c5b3216796bc0af0ce1007eaf24464fd4c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   flutter_test:
@@ -106,25 +118,28 @@ packages:
     source: sdk
     version: "0.0.0"
   geojson2h3:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../geojson2h3"
-      relative: true
-    source: path
+      name: geojson2h3
+      sha256: "7e6352fcfc8a8e9bf2f6ee628845136f5cec91c64f5c666e63c291a79d29cfcc"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      sha256: "06e8e8543e0c1cdd4dbedcd12f751166704b0bf5d239c27ba2a2e7527a745f2a"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_ffi:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_ffi"
-      relative: true
-    source: path
+      name: h3_ffi
+      sha256: "92ae60a423a3ea6b248df00e70ba892b458dc094286aff2842ec68eeeaece053"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_flutter:
     dependency: "direct main"
@@ -134,11 +149,12 @@ packages:
     source: path
     version: "0.6.2"
   h3_web:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_web"
-      relative: true
-    source: path
+      name: h3_web
+      sha256: f97291d19a5196641bca32bb4cb7d6378b1da076792a1969c094fb6389a24231
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   integration_test:
     dependency: "direct dev"
@@ -149,56 +165,64 @@ packages:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "5528c2f391ededb7775ec1daa69e65a2d61276f7552de2b5f7b8d34ee9fd4ab7"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   lints:
     dependency: transitive
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: "16db949ceee371e9b99d22f88fa3a73c4e59fd0afed0bd25fc336eb76c198b72"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.13"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      url: "https://pub.dartlang.org"
+      sha256: d92141dc6fe1dad30722f9aa826c7fbc896d021d792f80678280601aff8cf724
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: db9d4f58c908a4ba5953fcee2ae317c94889433e5024c27ce74a37f94267945b
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.2"
   platform:
     dependency: transitive
     description:
       name: platform
-      url: "https://pub.dartlang.org"
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   process:
     dependency: transitive
     description:
       name: process
-      url: "https://pub.dartlang.org"
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
     source: hosted
     version: "4.2.4"
   sky_engine:
@@ -210,79 +234,90 @@ packages:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   sync_http:
     dependency: transitive
     description:
       name: sync_http
-      url: "https://pub.dartlang.org"
+      sha256: "7f0cd72eca000d2e026bcd6f990b81d0ca06022ef4e32fb257b30d3d1014a961"
+      url: "https://pub.dev"
     source: hosted
     version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: ad540f65f92caa91bf21dfc8ffb8c589d6e4dc0c2267818b4cc2792857706206
+      url: "https://pub.dev"
     source: hosted
-    version: "0.4.13"
+    version: "0.4.16"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   vector_math:
     dependency: transitive
     description:
       name: vector_math
-      url: "https://pub.dartlang.org"
+      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      url: "https://pub.dev"
     source: hosted
-    version: "9.3.0"
+    version: "9.4.0"
   webdriver:
     dependency: transitive
     description:
       name: webdriver
-      url: "https://pub.dartlang.org"
+      sha256: ef67178f0cc7e32c1494645b11639dd1335f1d18814aa8435113a92e9ef9d841
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
 sdks:
-  dart: ">=2.18.0-146.0.dev <3.0.0"
+  dart: ">=2.18.0 <4.0.0"
   flutter: ">=2.5.0"

--- a/h3_flutter/example/pubspec.lock
+++ b/h3_flutter/example/pubspec.lock
@@ -106,25 +106,25 @@ packages:
     source: sdk
     version: "0.0.0"
   geojson2h3:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: geojson2h3
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../geojson2h3"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_common:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_common
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../h3_common"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_ffi:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_ffi
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../h3_ffi"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_flutter:
     dependency: "direct main"
@@ -134,11 +134,11 @@ packages:
     source: path
     version: "0.6.2"
   h3_web:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_web
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../h3_web"
+      relative: true
+    source: path
     version: "0.6.0"
   integration_test:
     dependency: "direct dev"

--- a/h3_flutter/example/pubspec.lock
+++ b/h3_flutter/example/pubspec.lock
@@ -7,7 +7,7 @@ packages:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.11"
+    version: "3.3.1"
   async:
     dependency: transitive
     description:
@@ -35,7 +35,7 @@ packages:
       name: clock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.1.1"
   collection:
     dependency: transitive
     description:
@@ -63,7 +63,7 @@ packages:
       name: fake_async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   ffi:
     dependency: transitive
     description:
@@ -77,7 +77,7 @@ packages:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -94,7 +94,7 @@ packages:
       name: flutter_lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.1"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -106,25 +106,25 @@ packages:
     source: sdk
     version: "0.0.0"
   geojson2h3:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../geojson2h3"
-      relative: true
-    source: path
+      name: geojson2h3
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_ffi:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_ffi"
-      relative: true
-    source: path
+      name: h3_ffi
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_flutter:
     dependency: "direct main"
@@ -132,13 +132,13 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.6.2"
   h3_web:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_web"
-      relative: true
-    source: path
+      name: h3_web
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   integration_test:
     dependency: "direct dev"
@@ -158,21 +158,21 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.11"
+    version: "0.12.12"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.5"
+    version: "0.2.0"
   meta:
     dependency: transitive
     description:
@@ -212,7 +212,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
@@ -240,21 +240,21 @@ packages:
       name: sync_http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.9"
+    version: "0.4.13"
   typed_data:
     dependency: transitive
     description:
@@ -268,14 +268,14 @@ packages:
       name: vector_math
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.3"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.3.0"
+    version: "9.3.0"
   webdriver:
     dependency: transitive
     description:
@@ -284,5 +284,5 @@ packages:
     source: hosted
     version: "3.0.0"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0-146.0.dev <3.0.0"
   flutter: ">=2.5.0"

--- a/h3_flutter/example/pubspec.yaml
+++ b/h3_flutter/example/pubspec.yaml
@@ -19,7 +19,7 @@ dev_dependencies:
     sdk: flutter
   integration_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 flutter:
   uses-material-design: true

--- a/h3_flutter/example/web/index.html
+++ b/h3_flutter/example/web/index.html
@@ -36,7 +36,7 @@
     // The value below is injected by flutter build, do not touch.
     var serviceWorkerVersion = null;
   </script>
-  <script defer src="https://unpkg.com/h3-js"></script>
+  <script defer src="https://unpkg.com/h3-js@3.7.2"></script>
   <!-- This script adds the flutter initialization JS code -->
   <script src="flutter.js" defer></script>
 </head>

--- a/h3_flutter/ios/Classes/h3lib/CMakeLists.txt
+++ b/h3_flutter/ios/Classes/h3lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
-set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "" FORCE)
+project(h3lib)
 
 FILE(GLOB CSources *.c)
 FILE(GLOB HSources *.h)
@@ -12,3 +12,7 @@ add_library( h3lib
              # Provides a relative path to your source file(s).
             ${CSources}
             ${HSources})
+
+if ( NOT ANDROID ) 
+    set_target_properties(h3lib PROPERTIES SUFFIX ".lib")
+endif()

--- a/h3_flutter/macos/Classes/h3lib/CMakeLists.txt
+++ b/h3_flutter/macos/Classes/h3lib/CMakeLists.txt
@@ -1,5 +1,5 @@
 cmake_minimum_required(VERSION 3.4.1)
-set(CMAKE_OSX_ARCHITECTURES "x86_64" CACHE INTERNAL "" FORCE)
+project(h3lib)
 
 FILE(GLOB CSources *.c)
 FILE(GLOB HSources *.h)
@@ -12,3 +12,7 @@ add_library( h3lib
              # Provides a relative path to your source file(s).
             ${CSources}
             ${HSources})
+
+if ( NOT ANDROID ) 
+    set_target_properties(h3lib PROPERTIES SUFFIX ".lib")
+endif()

--- a/h3_flutter/pubspec.yaml
+++ b/h3_flutter/pubspec.yaml
@@ -18,7 +18,7 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
-  flutter_lints: ^1.0.0
+  flutter_lints: ^2.0.1
 
 flutter:
   plugin:

--- a/h3_flutter/pubspec.yaml
+++ b/h3_flutter/pubspec.yaml
@@ -1,6 +1,6 @@
 name: h3_flutter
 description: The package provides Flutter version of the H3 Core library, a hexagon-based geographic grid system
-version: 0.6.2
+version: 0.6.3
 homepage: https://github.com/festelo/h3_dart
 
 environment:

--- a/h3_flutter/pubspec.yaml
+++ b/h3_flutter/pubspec.yaml
@@ -10,10 +10,10 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-  h3_ffi: ^0.6.0
-  h3_web: ^0.6.0
-  h3_common: ^0.6.0
-  geojson2h3: ^0.6.0
+  h3_ffi: ^0.6.1
+  h3_web: ^0.6.1
+  h3_common: ^0.6.1
+  geojson2h3: ^0.6.1
 
 dev_dependencies:
   flutter_test:

--- a/h3_web/CHANGELOG.md
+++ b/h3_web/CHANGELOG.md
@@ -1,3 +1,10 @@
+## 0.6.1
+* Fix web setup readme.
+* Fix web example
+* Fix web test
+* Add holes support to `polyfill` function
+* Update dependencies (incl. `h3_common` v6.0.1 and others)
+
 ## 0.6.0
 * Split `h3_dart` library into 5 libraries - `h3_dart`, `h3_ffi`, `h3_web`, `h3_common`, `geojson2h3`
 * Use `BigInt` instead of `int` for h3 indexes due to `web` specific.

--- a/h3_web/README.md
+++ b/h3_web/README.md
@@ -32,7 +32,7 @@ final hexagons = h3.polyfill(
 This library is built on top of `h3-js`, you have to import it.  
 Add next line to your `index.html`:
 ```html
-    <script defer src="https://unpkg.com/h3-js"></script>
+    <script defer src="https://unpkg.com/h3-js@3.7.2"></script>
 ```
 **Note, `main.dart.js` import should go after this line**
 

--- a/h3_web/example/pubspec.lock
+++ b/h3_web/example/pubspec.lock
@@ -5,232 +5,265 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
+      url: "https://pub.dev"
     source: hosted
     version: "52.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
+      url: "https://pub.dev"
     source: hosted
     version: "5.4.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: ed7cc591a948744994714375caf9a2ce89e1d82e8243997c8a2994d57181c212
+      url: "https://pub.dev"
     source: hosted
     version: "3.3.5"
   args:
     dependency: transitive
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
     version: "2.10.0"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
-      url: "https://pub.dartlang.org"
+      sha256: "500584fdb80bcb70a2990a5838338a757cc24bbf27d88bf791cbe9461c57cd5a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   browser_launcher:
     dependency: transitive
     description:
       name: browser_launcher
-      url: "https://pub.dartlang.org"
+      sha256: "6ee4c6b1f68a42e769ef6e663c4f56708522f7bce9d2ab6e308a37b612ffa4ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   build:
     dependency: transitive
     description:
       name: build
-      url: "https://pub.dartlang.org"
+      sha256: "3fbda25365741f8251b39f3917fb3c8e286a96fd068a5a242e11c2012d495777"
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
-      url: "https://pub.dartlang.org"
+      sha256: bf80fcfb46a29945b423bd9aad884590fb1dc69b330a4d4700cac476af1708d1
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
       name: build_daemon
-      url: "https://pub.dartlang.org"
+      sha256: "6bc5544ea6ce4428266e7ea680e945c68806c4aae2da0eb5e9ccf38df8d6acbf"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.0"
   build_modules:
     dependency: transitive
     description:
       name: build_modules
-      url: "https://pub.dartlang.org"
+      sha256: d02a5b40720692c8c4c385741afb1cc50b53f192a33fa5da1f2bdaec3ec6db3e
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.7"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
-      url: "https://pub.dartlang.org"
+      sha256: "7c35a3a7868626257d8aee47b51c26b9dba11eaddf3431117ed2744951416aab"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
-      url: "https://pub.dartlang.org"
+      sha256: b0a8a7b8a76c493e85f1b84bffa0588859a06197863dba8c9036b15581fd9727
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
-      url: "https://pub.dartlang.org"
+      sha256: "14febe0f5bac5ae474117a36099b4de6f1dbc52df6c5e55534b3da9591bf4292"
+      url: "https://pub.dev"
     source: hosted
     version: "7.2.7"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
-      url: "https://pub.dartlang.org"
+      sha256: ee45348ba9c2dfd2e165c0adf69311970fa620c6669c345ab533e16d0d119e3d
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.7"
   built_collection:
     dependency: transitive
     description:
       name: built_collection
-      url: "https://pub.dartlang.org"
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
     source: hosted
     version: "5.1.1"
   built_value:
     dependency: transitive
     description:
       name: built_value
-      url: "https://pub.dartlang.org"
+      sha256: "169565c8ad06adb760c3645bf71f00bff161b00002cace266cad42c5d22a7725"
+      url: "https://pub.dev"
     source: hosted
     version: "8.4.3"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.2"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
-      url: "https://pub.dartlang.org"
+      sha256: "0d43dd1288fd145de1ecc9a3948ad4a6d5a82f0a14c4fdd0892260787d975cbe"
+      url: "https://pub.dev"
     source: hosted
     version: "4.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
     version: "1.17.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
-      url: "https://pub.dartlang.org"
+      sha256: "7a03456c3490394c8e7665890333e91ae8a49be43542b616e414449ac358acd4"
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
   dds:
     dependency: transitive
     description:
       name: dds
-      url: "https://pub.dartlang.org"
+      sha256: a87ad70ffc15deb727f2943618aa999051ea4353dcc2175787931b57039a8c29
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.2"
   dds_service_extensions:
     dependency: transitive
     description:
       name: dds_service_extensions
-      url: "https://pub.dartlang.org"
+      sha256: "5aa29ecb1945743eed6b513ef4871468d14b6c1b6f8a5ec84c03f469e3f94fb2"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   devtools_shared:
     dependency: transitive
     description:
       name: devtools_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0f4264037e7a0f1aeadd425635024ad445b523963b246c61af7ffd22c3ed10da"
+      url: "https://pub.dev"
     source: hosted
     version: "2.20.1"
   dwds:
     dependency: transitive
     description:
       name: dwds
-      url: "https://pub.dartlang.org"
+      sha256: d2fd021d505610e57e07f068647d92f9639dde8a508b68f446a8ada2ea69e071
+      url: "https://pub.dev"
     source: hosted
     version: "16.0.1"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
     version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
       name: fixnum
-      url: "https://pub.dartlang.org"
+      sha256: "04be3e934c52e082558cc9ee21f42f5c1cd7a1262f4c63cd0357c08d5bba81ec"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   frontend_server_client:
     dependency: transitive
     description:
       name: frontend_server_client
-      url: "https://pub.dartlang.org"
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
-      url: "https://pub.dartlang.org"
+      sha256: f9e130f3259f52d26f0cfc0e964513796dafed572fa52e45d2f8d6ca14db39b2
+      url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      sha256: "06e8e8543e0c1cdd4dbedcd12f751166704b0bf5d239c27ba2a2e7527a745f2a"
+      url: "https://pub.dev"
+    source: hosted
     version: "0.6.0"
   h3_web:
     dependency: "direct main"
@@ -243,302 +276,345 @@ packages:
     dependency: transitive
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
     version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
     version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
     version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "323b7c70073cccf6b9b8d8b334be418a3293cfb612a560dc2737160a37bf61bd"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.6"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
     source: hosted
     version: "4.8.0"
   json_rpc_2:
     dependency: transitive
     description:
       name: json_rpc_2
-      url: "https://pub.dartlang.org"
+      sha256: "5e469bffa23899edacb7b22787780068d650b106a21c76db3c49218ab7ca447e"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
   lints:
     dependency: "direct dev"
     description:
       name: lints
-      url: "https://pub.dartlang.org"
+      sha256: "5e4a9cd06d447758280a8ac2405101e0e2094d2a1dbdd3756aec3fe7775ba593"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      url: "https://pub.dev"
     source: hosted
     version: "0.12.14"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "6c268b42ed578a53088d834796959e4a1814b5e9e164f147f580a386e5decf42"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   path:
     dependency: transitive
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
     version: "1.8.3"
   pointycastle:
     dependency: transitive
     description:
       name: pointycastle
-      url: "https://pub.dartlang.org"
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      url: "https://pub.dev"
     source: hosted
     version: "3.6.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
   protobuf:
     dependency: transitive
     description:
       name: protobuf
-      url: "https://pub.dartlang.org"
+      sha256: "01dd9bd0fa02548bf2ceee13545d4a0ec6046459d847b6b061d8a27237108a08"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
-      url: "https://pub.dartlang.org"
+      sha256: "75f6614d6dde2dc68948dffbaa4fe5dae32cd700eb9fb763fe11dfb45a3c4d0a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   scratch_space:
     dependency: transitive
     description:
       name: scratch_space
-      url: "https://pub.dartlang.org"
+      sha256: a469a9642a4d7ee406d6224a85446eb8baa9dd6d81e2f0b76770deae7bd32aab
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
     version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.1"
   shelf_proxy:
     dependency: transitive
     description:
       name: shelf_proxy
-      url: "https://pub.dartlang.org"
+      sha256: "3cdbff721092c755927d8695f696e13cff4b3ceb43306de136e69c38d5f574b8"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
     version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.3"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "490098075234dcedb83c5d949b4c93dad5e6b7702748de000be2b57b8e6b2427"
+      url: "https://pub.dev"
     source: hosted
     version: "0.10.11"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
     version: "1.9.1"
   sse:
     dependency: transitive
     description:
       name: sse
-      url: "https://pub.dartlang.org"
+      sha256: "3ff9088cac3f45aa8b91336f1962e3ea6c81baaba0bbba361c05f8aa7fb59442"
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
     version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
-      url: "https://pub.dartlang.org"
+      sha256: "14a00e794c7c11aa145a170587321aedce29769c08d7f58b1d141da75e3b1c6f"
+      url: "https://pub.dev"
     source: hosted
     version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.1"
   timing:
     dependency: transitive
     description:
       name: timing
-      url: "https://pub.dartlang.org"
+      sha256: "70a3b636575d4163c477e6de42f247a23b315ae20e86442bebe32d3cabf61c32"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   usage:
     dependency: transitive
     description:
       name: usage
-      url: "https://pub.dartlang.org"
+      sha256: ccc861ca619157046d961a1d7fa21a364476c574bb8f3e90219e41b9103adee0
+      url: "https://pub.dev"
     source: hosted
     version: "4.1.0"
   uuid:
     dependency: transitive
     description:
       name: uuid
-      url: "https://pub.dartlang.org"
+      sha256: "648e103079f7c64a36dc7d39369cabb358d377078a051d6ae2ad3aa539519313"
+      url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: e7fb6c2282f7631712b69c19d1bff82f3767eea33a2321c14fa59ad67ea391c7
+      url: "https://pub.dev"
     source: hosted
     version: "9.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
     version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      url: "https://pub.dev"
     source: hosted
     version: "2.3.0"
   webdev:
     dependency: "direct dev"
     description:
       name: webdev
-      url: "https://pub.dartlang.org"
+      sha256: c16fcac5198f4f4dd6189aa75b554a94094ed86b9b3fd041b719ec9650a75b1e
+      url: "https://pub.dev"
     source: hosted
     version: "2.7.12"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
     version: "1.2.0"
   yaml:
     dependency: transitive
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.18.0 <3.0.0"
+  dart: ">=2.19.0-345.0.dev <4.0.0"

--- a/h3_web/example/pubspec.lock
+++ b/h3_web/example/pubspec.lock
@@ -226,11 +226,11 @@ packages:
     source: hosted
     version: "2.2.0"
   h3_common:
-    dependency: transitive
+    dependency: "direct overridden"
     description:
-      name: h3_common
-      url: "https://pub.dartlang.org"
-    source: hosted
+      path: "../../h3_common"
+      relative: true
+    source: path
     version: "0.6.0"
   h3_web:
     dependency: "direct main"

--- a/h3_web/example/pubspec.lock
+++ b/h3_web/example/pubspec.lock
@@ -7,42 +7,42 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "40.0.0"
+    version: "52.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "5.4.0"
   archive:
     dependency: transitive
     description:
       name: archive
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.3.5"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   async:
     dependency: transitive
     description:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.9.0"
+    version: "2.10.0"
   bazel_worker:
     dependency: transitive
     description:
       name: bazel_worker
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   browser_launcher:
     dependency: transitive
     description:
@@ -56,14 +56,14 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.0"
+    version: "2.3.1"
   build_config:
     dependency: transitive
     description:
       name: build_config
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.1.1"
   build_daemon:
     dependency: transitive
     description:
@@ -77,35 +77,35 @@ packages:
       name: build_modules
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.5"
+    version: "4.0.7"
   build_resolvers:
     dependency: transitive
     description:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.9"
+    version: "2.1.0"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.11"
+    version: "2.3.3"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "7.2.3"
+    version: "7.2.7"
   build_web_compilers:
     dependency: "direct dev"
     description:
       name: build_web_compilers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.3"
+    version: "3.2.7"
   built_collection:
     dependency: transitive
     description:
@@ -119,35 +119,35 @@ packages:
       name: built_value
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.3.3"
+    version: "8.4.3"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.4.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.16.0"
+    version: "1.17.1"
   convert:
     dependency: transitive
     description:
       name: convert
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.2"
+    version: "3.1.1"
   crypto:
     dependency: transitive
     description:
@@ -161,42 +161,42 @@ packages:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.3"
+    version: "2.2.4"
   dds:
     dependency: transitive
     description:
       name: dds
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.1"
+    version: "2.7.2"
   dds_service_extensions:
     dependency: transitive
     description:
       name: dds_service_extensions
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   devtools_shared:
     dependency: transitive
     description:
       name: devtools_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.14.0"
+    version: "2.20.1"
   dwds:
     dependency: transitive
     description:
       name: dwds
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "14.0.3"
+    version: "16.0.1"
   file:
     dependency: transitive
     description:
       name: file
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.2"
+    version: "6.1.4"
   fixnum:
     dependency: transitive
     description:
@@ -210,27 +210,27 @@ packages:
       name: frontend_server_client
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   graphs:
     dependency: transitive
     description:
       name: graphs
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.2.0"
   h3_common:
-    dependency: "direct overridden"
+    dependency: transitive
     description:
-      path: "../../h3_common"
-      relative: true
-    source: path
+      name: h3_common
+      url: "https://pub.dartlang.org"
+    source: hosted
     version: "0.6.0"
   h3_web:
     dependency: "direct main"
@@ -245,7 +245,7 @@ packages:
       name: http
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
@@ -259,28 +259,28 @@ packages:
       name: http_parser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.0.1"
+    version: "4.0.2"
   io:
     dependency: transitive
     description:
       name: io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.4"
+    version: "0.6.5"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.5.0"
+    version: "4.8.0"
   json_rpc_2:
     dependency: transitive
     description:
@@ -294,21 +294,21 @@ packages:
       name: lints
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "2.0.1"
   logging:
     dependency: transitive
     description:
       name: logging
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.1"
   matcher:
     dependency: transitive
     description:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.12"
+    version: "0.12.14"
   meta:
     dependency: transitive
     description:
@@ -322,7 +322,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.4"
   package_config:
     dependency: transitive
     description:
@@ -336,14 +336,14 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.2"
-  pedantic:
+    version: "1.8.3"
+  pointycastle:
     dependency: transitive
     description:
-      name: pedantic
+      name: pointycastle
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.11.1"
+    version: "3.6.2"
   pool:
     dependency: transitive
     description:
@@ -364,14 +364,14 @@ packages:
       name: pub_semver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
   pubspec_parse:
     dependency: transitive
     description:
       name: pubspec_parse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   scratch_space:
     dependency: transitive
     description:
@@ -385,7 +385,7 @@ packages:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.1"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -413,56 +413,56 @@ packages:
       name: shelf_web_socket
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.0.3"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.11"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   sse:
     dependency: transitive
     description:
       name: sse
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.0"
+    version: "4.1.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   stream_transform:
     dependency: transitive
     description:
       name: stream_transform
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.1"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -476,7 +476,7 @@ packages:
       name: timing
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   typed_data:
     dependency: transitive
     description:
@@ -497,42 +497,42 @@ packages:
       name: uuid
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.6"
+    version: "3.0.7"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "8.3.0"
+    version: "9.4.0"
   watcher:
     dependency: transitive
     description:
       name: watcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.2.0"
+    version: "2.3.0"
   webdev:
     dependency: "direct dev"
     description:
       name: webdev
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.7.9"
+    version: "2.7.12"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   yaml:
     dependency: transitive
     description:
@@ -541,4 +541,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.18.0 <3.0.0"

--- a/h3_web/example/pubspec.yaml
+++ b/h3_web/example/pubspec.yaml
@@ -12,7 +12,7 @@ dependencies:
     path: ..
 
 dev_dependencies:
-  build_runner: ^2.1.4
-  build_web_compilers: ^3.2.1
-  lints: ^1.0.0
-  webdev: ^2.7.9
+  build_runner: ^2.3.3
+  build_web_compilers: ^3.2.7
+  lints: ^2.0.1
+  webdev: ^2.7.12

--- a/h3_web/example/web/index.html
+++ b/h3_web/example/web/index.html
@@ -8,7 +8,7 @@
     <meta name="scaffolded-by" content="https://github.com/dart-lang/sdk">
     <title>example</title>
     <link rel="stylesheet" href="styles.css">
-    <script defer src="https://unpkg.com/h3-js"></script>
+    <script defer src="https://unpkg.com/h3-js@3.7.2"></script>
     <script defer src="main.dart.js"></script>
 </head>
 

--- a/h3_web/lib/src/generated/types.dart
+++ b/h3_web/lib/src/generated/types.dart
@@ -117,9 +117,7 @@ external List<String> hexRing(
 /// expected to be holes.
 /// pairs instead of [lat, lng]
 @JS("h3.polyfill")
-external List<String> polyfill(
-    List<List<dynamic>> /*List<List<num>>|List<List<List<num>>>*/ coordinates,
-    num res,
+external List<String> polyfill(List<List<List<num>>> coordinates, num res,
     [bool isGeoJson]);
 
 /// Get the outlines of a set of H3 hexagons, returned in GeoJSON MultiPolygon

--- a/h3_web/lib/src/h3_web.dart
+++ b/h3_web/lib/src/h3_web.dart
@@ -127,11 +127,20 @@ class H3Web implements H3 {
   List<BigInt> polyfill({
     required List<GeoCoord> coordinates,
     required int resolution,
+    List<List<GeoCoord>> holes = const [],
   }) {
     assert(resolution >= 0 && resolution < 16,
         'Resolution must be in [0, 15] range');
     return h3_js
-        .polyfill(coordinates.map((e) => [e.lat, e.lon]).toList(), resolution)
+        .polyfill(
+          [
+            coordinates.map((e) => [e.lat, e.lon]).toList(),
+            ...holes
+                .map((arr) => arr.map((e) => [e.lat, e.lon]).toList())
+                .toList(),
+          ],
+          resolution,
+        )
         .cast<String>()
         .map((e) => e.toBigInt())
         .toList();

--- a/h3_web/pubspec.yaml
+++ b/h3_web/pubspec.yaml
@@ -1,6 +1,6 @@
 name: h3_web
 description: The package provides Dart version of the H3 Core library, a hexagon-based geographic grid system
-version: 0.6.0
+version: 0.6.1
 homepage: https://github.com/festelo/h3_dart
 
 environment:
@@ -8,7 +8,7 @@ environment:
 
 dependencies:
   js: ^0.6.4
-  h3_common: ^0.6.0
+  h3_common: ^0.6.1
 
 dev_dependencies:
   test: ^1.22.2

--- a/h3_web/pubspec.yaml
+++ b/h3_web/pubspec.yaml
@@ -11,7 +11,7 @@ dependencies:
   h3_common: ^0.6.0
 
 dev_dependencies:
-  test: ^1.21.2
+  test: ^1.22.2
   lints: ^2.0.0
   collection: ^1.16.0
   build_runner: ^2.3.3

--- a/h3_web/pubspec.yaml
+++ b/h3_web/pubspec.yaml
@@ -14,6 +14,6 @@ dev_dependencies:
   test: ^1.21.2
   lints: ^2.0.0
   collection: ^1.16.0
-  build_runner: ^2.1.4
-  build_web_compilers: ^3.2.1
+  build_runner: ^2.3.3
+  build_web_compilers: ^3.2.7
   build_test: ^2.1.5

--- a/h3_web/test/h3_test.dart
+++ b/h3_web/test/h3_test.dart
@@ -350,6 +350,46 @@ void main() async {
       );
     });
 
+    test('Hexagon with holes', () async {
+      final resolution = 5;
+      // wkt: POLYGON ((35 10, 45 45, 15 40, 10 20, 35 10),(20 30, 35 35, 30 20, 20 30))
+      final hexagons = h3.polyfill(
+        coordinates: const [
+          GeoCoord(lon: 35, lat: 10),
+          GeoCoord(lon: 45, lat: 45),
+          GeoCoord(lon: 15, lat: 40),
+          GeoCoord(lon: 10, lat: 20),
+          GeoCoord(lon: 35, lat: 10)
+        ],
+        holes: const [
+          [
+            GeoCoord(lon: 20, lat: 30),
+            GeoCoord(lon: 35, lat: 35),
+            GeoCoord(lon: 30, lat: 20),
+            GeoCoord(lon: 20, lat: 30)
+          ]
+        ],
+        resolution: resolution,
+      );
+
+      // point inside the hole 28.037109375000004 28.84467368077179 (this should be classified as outside)
+      //point inside 18.45703125 21.616579336740614
+      //point outside (far away) 52.55859375 23.48340065432562
+
+      final insideHoleIndex = h3.geoToH3(
+          GeoCoord(lon: 28.037109375000004, lat: 28.84467368077179),
+          resolution);
+      expect(hexagons.contains(insideHoleIndex), false);
+
+      final insideIndex = h3.geoToH3(
+          GeoCoord(lon: 18.45703125, lat: 21.616579336740614), resolution);
+      expect(hexagons.contains(insideIndex), true);
+
+      final outsideIndex = h3.geoToH3(
+          GeoCoord(lon: 52.55859375, lat: 23.48340065432562), resolution);
+      expect(hexagons.contains(outsideIndex), false);
+    });
+
     test('Transmeridian', () async {
       final hexagons = h3.polyfill(
         coordinates: const [

--- a/h3_web/test/h3_test.dart
+++ b/h3_web/test/h3_test.dart
@@ -11,7 +11,7 @@ import 'common.dart';
 import 'h3_js_injector.dart';
 
 void main() async {
-  await inject('https://unpkg.com/h3-js');
+  await inject('https://unpkg.com/h3-js@3.7.2');
 
   final h3 = H3Web();
 

--- a/scripts/build_h3.sh
+++ b/scripts/build_h3.sh
@@ -1,3 +1,4 @@
+rm -rf h3_ffi/c/h3lib/build 
 mkdir h3_ffi/c/h3lib/build
 cd h3_ffi/c/h3lib/build
 cmake .. -G "Unix Makefiles" 


### PR DESCRIPTION
## 0.6.1
* Fix `h3_web` setup readme.
* Add holes support to `polyfill` function (thanks [@iulian0512](https://github.com/iulian0512))
* Fix Android build for `h3_flutter` (thanks [@rtviwe](https://github.com/iulian0512))
* Fix `build_h3.sh` script for M1 mac
* Tests fix